### PR TITLE
Add conditional checks for the value of pllm

### DIFF
--- a/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_rcc.c
+++ b/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_rcc.c
@@ -1339,6 +1339,10 @@ void RCC_GetClocksFreq(RCC_ClocksTypeDef* RCC_Clocks)
     */    
     pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) >> 22;
     pllm = RCC->PLLCFGR & RCC_PLLCFGR_PLLM;
+
+    if(pllm == 0){
+      return;
+    }
     
     if (pllsource != 0)
     {

--- a/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c
+++ b/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c
@@ -423,6 +423,10 @@ void I2S_Init(SPI_TypeDef* SPIx, I2S_InitTypeDef* I2S_InitStruct)
     /* Get the PLLM value */
     pllm = (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM);
 
+    if(pllm == 0){
+      return;
+    }
+
     if((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLCFGR_PLLSRC_HSE)
     {
       /* Get the I2S source clock value */


### PR DESCRIPTION
## Fix For A Possible Floating Point Exception in stm32

This pull request attempts to fix a possible FPE that can be caused by accepting the value of 0 for the `RCC->PLLCFGR` which is assigned to pllm.