### PR TITLE
Add Null checks to pucSrc in ucFlash_Write from iflash.c

### DIFF
--- a/Peripherals/iflash.c
+++ b/Peripherals/iflash.c
@@ -234,7 +234,10 @@ uint8_t ucFlash_Compare(uint32_t ulFlashAddr, uint8_t *pucBuf, uint32_t ulSize)
 uint8_t ucFlash_Write(uint32_t ulFlashAddr, uint8_t *pucSrc, uint32_t ulSize)
 {
 	uint8_t ucRet = 0x00;
-	
+	/* Ensure that pucSrc is not NULL pointer */
+	if (pucSrc == NULL) {
+		return 1;
+	}
 	/*如果偏移地址超过芯片容量，则不改写输出缓冲区*/
 	if (ulFlashAddr + ulSize > FLASH_BASE_ADDR + FLASH_SIZE)
 	{


### PR DESCRIPTION
## Description

If `pucSrc` is `NULL` or pointer to `NULL`, it can cause null pointer dereferences later in `ucFlash_Compare` and also when the data is copied in case `FLASH_ProgramByte` is called.

## Patch

The patch adds null check to `pucSrc` to ensure the above scenario is handled gracefully.